### PR TITLE
feat: Refactor supplier status management in Prisma schema and relate…

### DIFF
--- a/prisma/migrations/20260212180000_supplier_estado/migration.sql
+++ b/prisma/migrations/20260212180000_supplier_estado/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable: add estado (0 = inactivo, 1 = activo) to suppliers, then remove status_id.
+-- The statuses table is left unchanged.
+
+-- Add estado (0 = inactivo, 1 = activo). Default 1 so existing rows stay active.
+ALTER TABLE "suppliers" ADD COLUMN "estado" INTEGER NOT NULL DEFAULT 1;
+
+-- Migrate: status_id 1 = activo (estado 1), other = inactivo (estado 0)
+UPDATE "suppliers" SET "estado" = 0 WHERE "status_id" != 1;
+
+ALTER TABLE "suppliers" DROP CONSTRAINT "suppliers_status_id_fkey";
+ALTER TABLE "suppliers" DROP COLUMN "status_id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,10 +31,9 @@ model ProductCategory {
 }
 
 model Status {
-  id        Int        @id @default(autoincrement())
-  name      String     @unique @db.VarChar(50)
-  suppliers Supplier[]
-  alerts    Alert[]
+  id     Int     @id @default(autoincrement())
+  name   String  @unique @db.VarChar(50)
+  alerts Alert[]
 
   @@map("statuses")
 }
@@ -112,8 +111,7 @@ model Supplier {
   last_order       DateTime?
   total_purchases  Decimal         @default(0) @db.Decimal(12, 2)
   rating           Decimal?        @db.Decimal(3, 2)
-  status_id        Int
-  status           Status          @relation(fields: [status_id], references: [id])
+  estado           Int             @default(1) // 0 = inactivo, 1 = activo
   payment_terms_id Int
   payment_term     PaymentTerm     @relation(fields: [payment_terms_id], references: [id])
   categories       SupplierCategory[]

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -48,7 +48,7 @@ async function main() {
   // 3. CATÁLOGOS - ESTADOS Y STATUS
   // ========================================
   console.log('Creando estados y status...')
-  const statuses = ['Activo', 'Inactivo', 'Activa', 'Resuelta', 'Pendiente']
+  const statuses = ['Activa', 'Resuelta', 'Pendiente']
   const stockStatuses = ['Disponible', 'Bajo', 'Agotado']
   const saleStatuses = ['Completada', 'Cancelada']
   const paymentMethods = ['Efectivo', 'Tarjeta', 'Transferencia']

--- a/src/controllers/suppliers.controller.js
+++ b/src/controllers/suppliers.controller.js
@@ -49,7 +49,6 @@ exports.list = async (req, res, next) => {
             category: true,
           },
         },
-        status: true,
         payment_term: true,
         productsList: true,
       },
@@ -138,13 +137,8 @@ exports.create = async (req, res, next) => {
       // prisma model uses payment_term relation
       createData.payment_term = { connect: { id: Number(data.payment_terms_id) } }
     }
-    if (data.status_id != null) {
-      createData.status = { connect: { id: Number(data.status_id) } }
-    }
-    // Ensure a status is connected (default to 1 if not provided)
-    if (!createData.status) {
-      createData.status = { connect: { id: 1 } }
-    }
+    // estado: 0 = inactivo, 1 = activo (default 1)
+    createData.estado = data.estado !== undefined && data.estado !== null ? Number(data.estado) : 1
 
     const created = await prisma.supplier.create({ data: createData })
     res.status(201).json(created)
@@ -161,7 +155,6 @@ exports.getOne = async (req, res, next) => {
             category: true,
           },
         },
-        status: true,
         payment_term: true,
         productsList: true,
       },
@@ -221,8 +214,8 @@ exports.update = async (req, res, next) => {
     if (data.payment_terms_id != null) {
       updateData.payment_term = { connect: { id: Number(data.payment_terms_id) } }
     }
-    if (data.status_id != null) {
-      updateData.status = { connect: { id: Number(data.status_id) } }
+    if (data.estado !== undefined && data.estado !== null) {
+      updateData.estado = Number(data.estado)
     }
 
     const updated = await prisma.supplier.update({ where: { id: req.params.id }, data: updateData })

--- a/src/services/supplierBulkImport.js
+++ b/src/services/supplierBulkImport.js
@@ -288,8 +288,8 @@ async function bulkCreateSuppliers(validRows) {
                 createData.rating = row.data.rating
             }
 
-            // Default status to active (id: 1)
-            createData.status = { connect: { id: 1 } }
+            // estado: 1 = activo por defecto
+            createData.estado = 1
 
             await prisma.supplier.create({ data: createData })
             created++


### PR DESCRIPTION
…d logic

- Updated the Prisma schema to replace the 'status_id' field with a new 'estado' field in the Supplier model, indicating active (1) or inactive (0) status.
- Adjusted the seeding script to reflect the removal of 'Inactivo' from the statuses array.
- Modified supplier controller methods to handle the new 'estado' field for supplier creation and updates.
- Updated bulk import functionality to set the default estado to active (1) for new suppliers.