### PR TITLE
fix(auth): enforce permissions consistently across API routes

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -152,6 +152,7 @@ async function main() {
     { code: 'alerts.manage', name: 'Gestionar alertas', description: 'Puede resolver y reasignar alertas' },
     { code: 'analytics.view', name: 'Ver analítica', description: 'Puede ver paneles de analítica' },
     { code: 'reports.view', name: 'Ver reportes', description: 'Puede ver y generar reportes' },
+    { code: 'scanner.view', name: 'Usar escáner', description: 'Puede usar el escáner de códigos de barras' },
 
     // Promociones
     { code: 'promotions.view', name: 'Ver promociones', description: 'Puede ver promociones' },
@@ -159,7 +160,6 @@ async function main() {
 
     // Mercancía (Registro de ingresos)
     { code: 'merchandise.view', name: 'Ver registros de mercancía', description: 'Puede ver el historial de ingresos de mercancía' },
-    { code: 'merchandise.register', name: 'Registrar mercancía', description: 'Puede registrar nuevos ingresos de mercancía' },
     { code: 'merchandise.details', name: 'Ver detalles de mercancía', description: 'Puede ver detalles completos de registros de mercancía' },
     { code: 'merchandise.reports', name: 'Generar reportes de mercancía', description: 'Puede generar reportes de ingresos de mercancía' },
     {
@@ -187,15 +187,17 @@ async function main() {
   }
   console.log('Permisos creados')
 
-  // Migrar permisos legacy suppliers.* → contacts.suppliers.* (roles que ya los tenían)
-  const suppliersToContactsSuppliers = [
+  // Migrar permisos legacy a su código vigente (roles que ya los tenían)
+  const legacyPermissionMigrations = [
     ['suppliers.view', 'contacts.suppliers.view'],
     ['suppliers.create', 'contacts.suppliers.create'],
     ['suppliers.edit', 'contacts.suppliers.edit'],
     ['suppliers.delete', 'contacts.suppliers.delete'],
     ['suppliers.import', 'contacts.suppliers.import'],
+    // merchandise.register era un duplicado muerto: la UI y las rutas usan products.register_incoming
+    ['merchandise.register', 'products.register_incoming'],
   ]
-  for (const [oldCode, newCode] of suppliersToContactsSuppliers) {
+  for (const [oldCode, newCode] of legacyPermissionMigrations) {
     const oldP = await prisma.permission.findUnique({ where: { code: oldCode } })
     const newP = await prisma.permission.findUnique({ where: { code: newCode } })
     if (!oldP || !newP) continue
@@ -248,20 +250,6 @@ async function main() {
       skipDuplicates: true,
     })
     console.log(`  ${adminPermissions.length} permisos asignados al rol 'admin'`)
-  }
-
-  // Quién tenía merchandise.details recibe también merchandise.mark_paid (misma capacidad operativa)
-  const detailsPerm = await prisma.permission.findUnique({ where: { code: 'merchandise.details' } })
-  const markPaidPerm = await prisma.permission.findUnique({ where: { code: 'merchandise.mark_paid' } })
-  if (detailsPerm && markPaidPerm) {
-    const withDetails = await prisma.rolePermission.findMany({ where: { permission_id: detailsPerm.id } })
-    if (withDetails.length) {
-      await prisma.rolePermission.createMany({
-        data: withDetails.map((rp) => ({ role_id: rp.role_id, permission_id: markPaidPerm.id })),
-        skipDuplicates: true,
-      })
-      console.log(`  merchandise.mark_paid replicado a roles que tenían merchandise.details (${withDetails.length} filas)`)
-    }
   }
 
   // ========================================

--- a/src/routes/analytics.routes.js
+++ b/src/routes/analytics.routes.js
@@ -10,7 +10,10 @@
 
 const { Router } = require('express')
 const ctrl = require('../controllers/analytics.controller')
+const { Auth, hasPermission } = require('../middlewares/autenticacion')
 const router = Router()
+
+router.use(Auth, hasPermission('analytics.view'))
 
 /**
  * @openapi

--- a/src/routes/catalogs.routes.js
+++ b/src/routes/catalogs.routes.js
@@ -10,6 +10,7 @@
 
 const { Router } = require('express')
 const Catalogs = require('../controllers/catalogs.controller')
+const { Auth } = require('../middlewares/autenticacion')
 const router = Router()
 
 /**
@@ -25,7 +26,7 @@ const router = Router()
  *       200:
  *         description: OK
  */
-router.get('/', Catalogs.all)
+router.get('/', Auth, Catalogs.all)
 
 /**
  * @openapi
@@ -37,7 +38,7 @@ router.get('/', Catalogs.all)
  *       200:
  *         description: OK
  */
-router.get('/statuses', Catalogs.statuses)
+router.get('/statuses', Auth, Catalogs.statuses)
 
 // Mount product categories management
 router.use('/product-categories', require('./productCategories.routes'))

--- a/src/routes/incomingMerchandise.routes.js
+++ b/src/routes/incomingMerchandise.routes.js
@@ -30,22 +30,10 @@ router.get('/report/pdf', Auth, hasPermission('merchandise.reports'), IncomingMe
  * PATCH /api/incoming-merchandise/:id/payment
  * Actualizar datos de pago del registro
  */
-router.patch(
-  '/:id/payment',
-  Auth,
-  hasPermission(
-    'merchandise.mark_paid',
-    'merchandise.details',
-    'products.register_incoming'
-  ),
-  IncomingMerchandise.updatePayment
-)
+// Solo el permiso dedicado autoriza tocar pagos: ver detalles NO implica poder abonar.
+const paymentEditors = hasPermission('merchandise.mark_paid')
 
-const paymentEditors = hasPermission(
-  'merchandise.mark_paid',
-  'merchandise.details',
-  'products.register_incoming'
-)
+router.patch('/:id/payment', Auth, paymentEditors, IncomingMerchandise.updatePayment)
 
 /**
  * POST /api/incoming-merchandise/:id/payments

--- a/src/routes/paymentTerms.routes.js
+++ b/src/routes/paymentTerms.routes.js
@@ -13,11 +13,13 @@ const { Auth, hasAnyRole, hasPermission } = require('../middlewares/autenticacio
 const ctrl = require('../controllers/paymentTerms.controller')
 const router = Router()
 
-// GET /catalogs/payment-terms
-router.get('/', ctrl.list)
+const canManage = hasPermission('catalogs.manage')
+
+// GET /catalogs/payment-terms (lectura: cualquier usuario autenticado, alimenta selects)
+router.get('/', Auth, ctrl.list)
 
 // GET /catalogs/payment-terms/template
-router.get('/template', ctrl.downloadTemplate)
+router.get('/template', Auth, canManage, ctrl.downloadTemplate)
 
 // POST /catalogs/payment-terms/validate-import-mapped
 router.post('/validate-import-mapped', Auth, hasPermission('catalogs.manage'), ctrl.validateImportMapped)
@@ -26,15 +28,15 @@ router.post('/validate-import-mapped', Auth, hasPermission('catalogs.manage'), c
 router.post('/bulk-import-mapped', Auth, hasPermission('catalogs.manage'), ctrl.bulkImportMapped)
 
 // POST /catalogs/payment-terms
-router.post('/', ctrl.create)
+router.post('/', Auth, canManage, ctrl.create)
 
 // PUT /catalogs/payment-terms/:id
-router.put('/:id', ctrl.update)
+router.put('/:id', Auth, canManage, ctrl.update)
 
 // DELETE /catalogs/payment-terms/:id (soft delete)
-router.delete('/:id', ctrl.remove)
+router.delete('/:id', Auth, canManage, ctrl.remove)
 
 // PATCH /catalogs/payment-terms/:id/restore
-router.patch('/:id/restore', ctrl.restore)
+router.patch('/:id/restore', Auth, canManage, ctrl.restore)
 
 module.exports = router

--- a/src/routes/productCategories.routes.js
+++ b/src/routes/productCategories.routes.js
@@ -43,7 +43,7 @@ const uploadImage = multer({
  *       200:
  *         description: Lista de categorías
  */
-router.get('/', ctrl.list)
+router.get('/', Auth, ctrl.list)
 
 /**
  * @openapi
@@ -61,7 +61,7 @@ router.get('/', ctrl.list)
  *               type: string
  *               format: binary
  */
-router.get('/template', ctrl.downloadTemplate)
+router.get('/template', Auth, hasPermission('catalogs.manage'), ctrl.downloadTemplate)
 
 /**
  * @openapi
@@ -162,7 +162,7 @@ router.post(
  *       201:
  *         description: Creada
  */
-router.post('/', ctrl.create)
+router.post('/', Auth, hasPermission('catalogs.manage'), ctrl.create)
 
 /**
  * @openapi
@@ -189,7 +189,7 @@ router.post('/', ctrl.create)
  *       200:
  *         description: Actualizada
  */
-router.put('/:id', ctrl.update)
+router.put('/:id', Auth, hasPermission('catalogs.manage'), ctrl.update)
 
 /**
  * @openapi
@@ -207,7 +207,7 @@ router.put('/:id', ctrl.update)
  *       200:
  *         description: Eliminada
  */
-router.delete('/:id', ctrl.remove)
+router.delete('/:id', Auth, hasPermission('catalogs.manage'), ctrl.remove)
 
 /**
  * @openapi
@@ -225,6 +225,6 @@ router.delete('/:id', ctrl.remove)
  *       200:
  *         description: Restaurada
  */
-router.patch('/:id/restore', ctrl.restore)
+router.patch('/:id/restore', Auth, hasPermission('catalogs.manage'), ctrl.restore)
 
 module.exports = router

--- a/src/routes/products.routes.js
+++ b/src/routes/products.routes.js
@@ -87,7 +87,7 @@ const router = Router()
  *               items:
  *                 $ref: '#/components/schemas/Product'
  */
-router.get('/', Products.list)
+router.get('/', Auth, Products.list)
 
 /**
  * @openapi
@@ -125,7 +125,7 @@ router.get('/critical', Auth, hasPermission('products.view', 'alerts.view'), Pro
  *               type: string
  *               format: binary
  */
-router.get('/report.pdf', Products.reportPdf)
+router.get('/report.pdf', Auth, hasPermission('products.export', 'reports.view'), Products.reportPdf)
 
 router.get('/availability', Auth, hasPermission('products.view', 'sales.create', 'orders.view', 'quotes.view'), Products.availability)
 
@@ -145,7 +145,7 @@ router.get('/availability', Auth, hasPermission('products.view', 'sales.create',
  *               type: string
  *               format: binary
  */
-router.get('/import-template', Products.getImportTemplate)
+router.get('/import-template', Auth, hasPermission('products.import'), Products.getImportTemplate)
 
 /**
  * @openapi
@@ -295,9 +295,9 @@ router.post(
  *               $ref: '#/components/schemas/Product'
  *       404: { description: No encontrado }
  */
-router.get('/:id/bom', Products.getBom)
+router.get('/:id/bom', Auth, Products.getBom)
 router.put('/:id/bom', Auth, hasPermission('products.edit'), Products.updateBom)
-router.get('/:id', Products.getOne)
+router.get('/:id', Auth, Products.getOne)
 
 /**
  * @openapi

--- a/src/routes/promotions.routes.js
+++ b/src/routes/promotions.routes.js
@@ -16,6 +16,12 @@
 const express = require('express')
 const router = express.Router()
 const controller = require('../controllers/promotions.controller')
+const { Auth, hasPermission } = require('../middlewares/autenticacion')
+
+// Lecturas y validación de códigos: cualquier usuario autenticado (el POS las necesita).
+// Mutaciones: solo quien gestiona promociones.
+router.use(Auth)
+const canManage = hasPermission('promotions.manage')
 
 /**
  * @swagger
@@ -53,7 +59,7 @@ router.get('/types', controller.getTypes)
  *     summary: Seed initial promotion types
  *     tags: [Promotions]
  */
-router.post('/types/seed', controller.seedTypes)
+router.post('/types/seed', canManage, controller.seedTypes)
 
 /**
  * @swagger
@@ -109,7 +115,7 @@ router.get('/:id', controller.getById)
  *     summary: Create a new promotion
  *     tags: [Promotions]
  */
-router.post('/', controller.create)
+router.post('/', canManage, controller.create)
 
 /**
  * @swagger
@@ -118,7 +124,7 @@ router.post('/', controller.create)
  *     summary: Update a promotion
  *     tags: [Promotions]
  */
-router.put('/:id', controller.update)
+router.put('/:id', canManage, controller.update)
 
 /**
  * @swagger
@@ -127,7 +133,7 @@ router.put('/:id', controller.update)
  *     summary: Delete a promotion
  *     tags: [Promotions]
  */
-router.delete('/:id', controller.delete)
+router.delete('/:id', canManage, controller.delete)
 
 /**
  * @swagger
@@ -136,7 +142,7 @@ router.delete('/:id', controller.delete)
  *     summary: Generate random promotion codes
  *     tags: [Promotions]
  */
-router.post('/generate-codes', controller.generateCodes)
+router.post('/generate-codes', canManage, controller.generateCodes)
 
 /**
  * @swagger
@@ -145,7 +151,7 @@ router.post('/generate-codes', controller.generateCodes)
  *     summary: Add codes to an existing promotion
  *     tags: [Promotions]
  */
-router.post('/:id/codes', controller.addCodes)
+router.post('/:id/codes', canManage, controller.addCodes)
 
 /**
  * @swagger
@@ -154,7 +160,7 @@ router.post('/:id/codes', controller.addCodes)
  *     summary: Delete a code from a promotion
  *     tags: [Promotions]
  */
-router.delete('/:id/codes/:codeId', controller.deleteCode)
+router.delete('/:id/codes/:codeId', canManage, controller.deleteCode)
 
 module.exports = router
 

--- a/src/routes/reports.routes.js
+++ b/src/routes/reports.routes.js
@@ -24,12 +24,14 @@ const {
 
 const router = Router()
 
-router.get('/sales', salesReport)
-router.get('/inventory', inventoryReport)
-router.get('/suppliers', suppliersReport)
-router.get('/financial', financialReport)
-router.get('/alerts', alertsReport)
-router.get('/products', productsReport)
+const canViewReports = hasPermission('reports.view')
+
+router.get('/sales', Auth, canViewReports, salesReport)
+router.get('/inventory', Auth, canViewReports, inventoryReport)
+router.get('/suppliers', Auth, canViewReports, suppliersReport)
+router.get('/financial', Auth, canViewReports, financialReport)
+router.get('/alerts', Auth, canViewReports, alertsReport)
+router.get('/products', Auth, canViewReports, productsReport)
 router.get(
   '/merchandise',
   Auth,

--- a/src/routes/returns.routes.js
+++ b/src/routes/returns.routes.js
@@ -11,21 +11,24 @@
 const express = require('express')
 const router = express.Router()
 const controller = require('../controllers/returns.controller')
-const { Auth } = require('../middlewares/autenticacion')
+const { Auth, hasPermission } = require('../middlewares/autenticacion')
 
 // Proteger todas las rutas con JWT
 router.use(Auth)
 
+const canView = hasPermission('returns.view', 'returns.manage')
+const canManage = hasPermission('returns.manage')
+
 // GET /api/returns - Listar devoluciones
-router.get('/', controller.list)
+router.get('/', canView, controller.list)
 
 // GET /api/returns/:id - Detalle de una devolución
-router.get('/:id', controller.getById)
+router.get('/:id', canView, controller.getById)
 
 // POST /api/returns - Crear nueva devolución
-router.post('/', controller.create)
+router.post('/', canManage, controller.create)
 
 // PATCH /api/returns/:id/status - Actualizar estado de devolución
-router.patch('/:id/status', controller.updateStatus)
+router.patch('/:id/status', canManage, controller.updateStatus)
 
 module.exports = router

--- a/src/routes/sales.routes.js
+++ b/src/routes/sales.routes.js
@@ -104,7 +104,7 @@ router.get('/', Auth, hasPermission('sales.view'), Sales.list)
  *       404:
  *         description: Venta no encontrada
  */
-router.get('/:id', Sales.getById)
+router.get('/:id', Auth, hasPermission('sales.view', 'sales.view_detail', 'sales.view_invoice', 'returns.manage'), Sales.getById)
 
 /**
  * @openapi

--- a/src/routes/usuarios.routes.js
+++ b/src/routes/usuarios.routes.js
@@ -74,7 +74,7 @@ const upload = multer({
  *             schema:
  *               $ref: '#/components/schemas/AuthResponse'
  */
-router.post('/register', controller.register)
+router.post('/register', Auth, hasPermission('users.create'), controller.register)
 
 /**
  * @openapi


### PR DESCRIPTION
- Remove dead duplicate permission merchandise.register; seed migrates role assignments to products.register_incoming (the code the UI uses)
- Payment/abono endpoints now require merchandise.mark_paid only: viewing details no longer implies editing payments
- Add permission checks to returns (view/manage split)
- Require auth + promotions.manage on promotion mutations (routes were fully public before)
- Require auth on product/catalog/payment-term/category reads; gate their mutations behind catalogs.manage
- Gate reports behind reports.view and analytics behind analytics.view
- Gate sale detail, product PDF/export, import templates
- /auth/register now requires users.create (admin-only user creation)
- Add missing scanner.view permission to catalog
- Stop replicating merchandise.mark_paid to roles with merchandise.details